### PR TITLE
Add logging for job applications and surface in dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ temp_resume.pdf
 resumes/feedback_log.jsonl
 smart_scraper/scraped_jobs.jsonl
 data/resume_match_results.json
+dashboard/application_log.jsonl
 
 # Editor / OS files
 .DS_Store

--- a/launch_autopilot.py
+++ b/launch_autopilot.py
@@ -13,6 +13,7 @@ from worker.keyword_matcher import match_jobs_to_resume
 from worker.playwright_apply import auto_detect_and_apply
 from worker.recruiter_message_generator import generate_message
 from worker.linkedin_xing_auto_connect import send_connection_requests
+from worker.application_logger import log_application
 
 RESUME_PATH = "config/resume.pdf"
 
@@ -50,6 +51,8 @@ def main():
     for job in matches:
         msg = generate_message("Candidate", job, recipient_name="Hiring Team")
         applied = apply_with_retry(job)
+        status = "applied" if applied else "failed"
+        log_application(job, status, recruiter_msg=msg)
         print(f"""💌 Recruiter Message:{msg}""")
 
     send_connection_requests()

--- a/tests/test_application_logger.py
+++ b/tests/test_application_logger.py
@@ -1,0 +1,19 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from worker import application_logger as al
+
+
+def test_log_and_read(tmp_path, monkeypatch):
+    log_path = tmp_path / "app.jsonl"
+    monkeypatch.setattr(al, "LOG_PATH", log_path)
+    al.log_application({"title": "T", "company": "C"}, "applied", recruiter_msg="hello")
+    entries = list(al.read_application_log())
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["title"] == "T"
+    assert entry["company"] == "C"
+    assert entry["status"] == "applied"
+    assert entry["recruiter_msg"] == "hello"

--- a/ui/dashboard_ui.py
+++ b/ui/dashboard_ui.py
@@ -5,6 +5,7 @@ from worker.keyword_matcher import match_jobs_to_resume
 from worker.recruiter_message_generator import generate_message
 from extensions.mock_interview import ask_question
 from worker.playwright_apply import simulate_job_apply
+from worker.application_logger import read_application_log
 from pathlib import Path
 
 st.set_page_config(page_title="AI Job Autopilot", layout="wide")
@@ -42,3 +43,12 @@ if resume_text:
     if st.button("Generate Outreach Message"):
         msg = generate_message("Security Engineer", "Berlin")
         st.code(msg, language="text")
+
+# Display application log
+st.markdown("---")
+st.markdown("### 📊 Application Log")
+log_entries = read_application_log()
+if log_entries:
+    st.table(log_entries)
+else:
+    st.info("No applications recorded yet.")

--- a/worker/application_logger.py
+++ b/worker/application_logger.py
@@ -1,0 +1,50 @@
+"""Utility for logging job application attempts.
+
+Writes each application attempt to ``dashboard/application_log.jsonl`` so
+it can be visualised by the Streamlit dashboard.  Each entry contains the
+job metadata, application status and optional recruiter message.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+
+LOG_PATH = Path("dashboard/application_log.jsonl")
+
+
+def log_application(job: Dict, status: str, recruiter_msg: str | None = None) -> None:
+    """Append an application attempt to the log file.
+
+    Parameters
+    ----------
+    job: mapping with at least ``title`` and ``company`` keys
+    status: short string describing the outcome (e.g. ``"applied"`` or
+        ``"failed"``)
+    recruiter_msg: optional message sent to the recruiter
+    """
+    LOG_PATH.parent.mkdir(exist_ok=True)
+    entry = {
+        "title": job.get("title"),
+        "company": job.get("company"),
+        "location": job.get("location"),
+        "url": job.get("url"),
+        "status": status,
+        "recruiter_msg": recruiter_msg,
+    }
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def read_application_log(limit: int | None = None) -> Iterable[Dict]:
+    """Return entries from the application log.
+
+    Parameters
+    ----------
+    limit: optionally limit the number of returned entries
+    """
+    if not LOG_PATH.exists():
+        return []
+    with LOG_PATH.open("r", encoding="utf-8") as f:
+        lines = f.readlines()[-limit:] if limit else f.readlines()
+    return [json.loads(line) for line in lines]

--- a/worker/playwright_apply.py
+++ b/worker/playwright_apply.py
@@ -2,6 +2,7 @@ import os
 import time
 from dotenv import load_dotenv
 from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+from .application_logger import log_application
 
 load_dotenv()
 
@@ -26,6 +27,7 @@ def simulate_job_apply(job, config=None, recruiter_msg: str | None = None):
     print(f"[✅] Simulated applying to job: {job['title']} at {job['company']}")
     if recruiter_msg:
         print(f"    ↳ recruiter message: {recruiter_msg}")
+    log_application(job, "simulated", recruiter_msg=recruiter_msg)
 
 
 def real_linkedin_apply(job_url, resume_path=RESUME_PATH):


### PR DESCRIPTION
## Summary
- add `application_logger` to record application attempts
- log outcomes from autoplay pipeline and simulated applies
- render application log in Streamlit dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd628c63408323a2065b0c9167bd52