### PR TITLE
Enhance resume parser with multi-AI analysis and unify UI theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,9 +1,9 @@
 [theme]
-primaryColor = "#4facfe"
-backgroundColor = "#0f172a"
-secondaryBackgroundColor = "#1e293b"
-textColor = "#e2e8f0"
-font = "sans serif"
+primaryColor = "#667eea"
+backgroundColor = "#f8fafc"
+secondaryBackgroundColor = "#ffffff"
+textColor = "#1a202c"
+font = "Inter"
 
 [server]
 headless = true

--- a/parser/resume_parser.py
+++ b/parser/resume_parser.py
@@ -1,14 +1,55 @@
-import os
-from pyresparser import ResumeParser
+"""Resume parsing utility using multi-AI analysis.
 
-def parse_resume(resume_path):
+This module extracts text from a PDF resume, parses it using the
+``MultiAIResumeParser`` which can leverage OpenAI, Gemini and other
+providers, and ensures the total years of experience are calculated.
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+# Ensure repository root is on ``sys.path`` for imports when run as a script
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.core.pdf_text_extractor import EnhancedPDFExtractor
+from src.ml.multi_ai_resume_parser import (
+    parse_resume_with_multi_ai,
+    calculate_total_experience,
+)
+
+
+def parse_resume(resume_path: str) -> Dict[str, Any]:
+    """Parse a resume PDF and return structured data.
+
+    Parameters
+    ----------
+    resume_path: str
+        Path to the resume PDF file.
+    """
+
     if not os.path.exists(resume_path):
         raise FileNotFoundError(f"Resume not found: {resume_path}")
-    data = ResumeParser(resume_path).get_extracted_data()
-    print("Extracted Resume Data:")
-    for k, v in data.items():
-        print(f"{k}: {v}")
-    return data
+
+    extractor = EnhancedPDFExtractor()
+    extraction = extractor.extract_text(resume_path)
+
+    result = parse_resume_with_multi_ai(extraction.text)
+
+    # Ensure years of experience is always present
+    career = result.setdefault("career_analysis", {})
+    if not career.get("years_of_experience") and result.get("experience"):
+        career["years_of_experience"] = calculate_total_experience(
+            result["experience"]
+        )
+
+    return result
+
 
 if __name__ == "__main__":
-    parse_resume("config/resume.pdf")
+    data = parse_resume("config/resume.pdf")
+    print("Extracted Resume Data:")
+    for key, value in data.items():
+        print(f"{key}: {value}")
+

--- a/tests/unit/test_multi_ai_resume_parser.py
+++ b/tests/unit/test_multi_ai_resume_parser.py
@@ -1,0 +1,33 @@
+"""Tests for the MultiAIResumeParser experience calculation."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.ml.multi_ai_resume_parser import MultiAIResumeParser, calculate_total_experience
+
+
+def test_calculate_total_experience_and_merge():
+    parser = MultiAIResumeParser()
+    # Prepare mock results with experience entries but without years_of_experience
+    results = [
+        (
+            "test",
+            {
+                "experience": [
+                    {"duration_months": 12},
+                    {"duration_months": 24},
+                ],
+                "career_analysis": {},
+            },
+        )
+    ]
+
+    merged = parser._merge_ai_results(results)
+    assert merged["career_analysis"]["years_of_experience"] == 3.0
+
+
+def test_calculate_total_experience_helper():
+    experience = [{"duration_months": 6}, {"duration_months": 18}]
+    assert calculate_total_experience(experience) == 2.0

--- a/ui/enhanced_dashboard.py
+++ b/ui/enhanced_dashboard.py
@@ -20,6 +20,8 @@ from typing import Dict, List, Optional
 import yaml
 import asyncio
 
+from theme import apply_theme
+
 # Add parent directory to path for imports
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -41,11 +43,13 @@ st.set_page_config(
     initial_sidebar_state="expanded"
 )
 
+apply_theme()
+
 # Custom CSS for modern design
 st.markdown("""
 <style>
     .main-header {
-        background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+        background: linear-gradient(90deg, var(--primary-color) 0%, var(--secondary-color) 100%);
         padding: 2rem;
         border-radius: 10px;
         margin-bottom: 2rem;
@@ -57,7 +61,7 @@ st.markdown("""
         padding: 1.5rem;
         border-radius: 10px;
         box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        border-left: 4px solid #667eea;
+        border-left: 4px solid var(--primary-color);
     }
     
     .status-success {
@@ -93,7 +97,7 @@ st.markdown("""
     }
     
     .stProgress .st-bo {
-        background-color: #667eea;
+        background-color: var(--primary-color);
     }
 </style>
 """, unsafe_allow_html=True)
@@ -213,7 +217,7 @@ if page == "🏠 Dashboard Overview":
             })
             
             fig = px.line(df, x='Date', y='Applications', title='📈 Application Activity (Last 7 Days)')
-            fig.update_traces(line_color='#667eea', line_width=3)
+            fig.update_traces(line_color='var(--primary-color)', line_width=3)
             fig.update_layout(showlegend=False)
             st.plotly_chart(fig, use_container_width=True)
         else:
@@ -748,7 +752,7 @@ elif page == "📊 Analytics & Reports":
             y=list(activity_data.values()),
             title="System Activity Summary"
         )
-        fig.update_traces(marker_color='#667eea')
+        fig.update_traces(marker_color='var(--primary-color)')
         st.plotly_chart(fig, use_container_width=True)
         
         # Detailed analytics
@@ -772,7 +776,7 @@ elif page == "📊 Analytics & Reports":
                     columns=['Company', 'Applications']
                 )
                 fig = px.bar(company_df, x='Company', y='Applications')
-                fig.update_traces(marker_color='#764ba2')
+                fig.update_traces(marker_color='var(--secondary-color)')
                 st.plotly_chart(fig, use_container_width=True)
         
         # Performance metrics

--- a/ui/premium_ui.py
+++ b/ui/premium_ui.py
@@ -22,6 +22,8 @@ import tempfile
 import random
 import re
 
+from theme import apply_theme
+
 # Add parent directory to path for imports
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -39,6 +41,8 @@ try:
 except Exception:
     pass
 
+apply_theme()
+
 def load_premium_css():
     """Load clean, professional theme with excellent readability"""
     st.markdown("""
@@ -47,7 +51,7 @@ def load_premium_css():
         
         /* CLEAN PROFESSIONAL THEME */
         .stApp {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
             font-family: 'Inter', sans-serif !important;
         }
         
@@ -82,7 +86,7 @@ def load_premium_css():
         
         /* CLEAN BUTTONS */
         .stButton > button {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
             color: white !important;
             border: none !important;
             border-radius: 8px !important;
@@ -114,7 +118,7 @@ def load_premium_css():
         .stTextInput > div > div > input:focus,
         .stSelectbox > div > div > div:focus,
         .stNumberInput > div > div > input:focus {
-            border-color: #667eea !important;
+            border-color: var(--primary-color) !important;
             box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2) !important;
             outline: none !important;
         }
@@ -122,14 +126,14 @@ def load_premium_css():
         /* CLEAN FILE UPLOADER */
         .stFileUploader {
             background: rgba(255, 255, 255, 0.8) !important;
-            border: 2px dashed #667eea !important;
+            border: 2px dashed var(--primary-color) !important;
             border-radius: 12px !important;
             padding: 2rem !important;
             text-align: center !important;
         }
         
         .stFileUploader:hover {
-            border-color: #764ba2 !important;
+            border-color: var(--secondary-color) !important;
             background: rgba(255, 255, 255, 0.9) !important;
         }
         
@@ -152,7 +156,7 @@ def load_premium_css():
         
         /* METRIC CARDS */
         .metric-card {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
             color: white !important;
             border-radius: 16px !important;
             padding: 1.5rem !important;
@@ -184,7 +188,7 @@ def load_premium_css():
         
         /* BEAUTIFUL HEADER */
         .premium-header {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
             padding: 4rem 2rem !important;
             border-radius: 25px !important;
             color: white !important;
@@ -250,7 +254,7 @@ def load_premium_css():
         }
         
         .stTabs [aria-selected="true"] {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
             color: white !important;
             box-shadow: 0 8px 20px rgba(102, 126, 234, 0.3) !important;
         }
@@ -261,7 +265,7 @@ def load_premium_css():
             border-radius: 16px !important;
             padding: 1.5rem !important;
             margin: 1rem 0 !important;
-            border-left: 5px solid #667eea !important;
+            border-left: 5px solid var(--primary-color) !important;
             box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08) !important;
             transition: all 0.3s ease !important;
             backdrop-filter: blur(5px) !important;
@@ -270,7 +274,7 @@ def load_premium_css():
         .job-card:hover {
             transform: translateX(8px) translateY(-2px) !important;
             box-shadow: 0 15px 35px rgba(0, 0, 0, 0.12) !important;
-            border-left-color: #764ba2 !important;
+            border-left-color: var(--secondary-color) !important;
         }
         
         .job-title {
@@ -281,14 +285,14 @@ def load_premium_css():
         }
         
         .job-company {
-            color: #667eea !important;
+            color: var(--primary-color) !important;
             font-weight: 600 !important;
             font-size: 1rem !important;
         }
         
         /* PROGRESS BARS */
         .stProgress > div > div > div {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%) !important;
+            background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
             border-radius: 10px !important;
         }
         

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -1,0 +1,30 @@
+import streamlit as st
+
+
+def apply_theme() -> None:
+    """Inject global CSS variables for consistent theming."""
+    st.markdown(
+        """
+        <style>
+            :root {
+                --primary-color: #667eea;
+                --secondary-color: #764ba2;
+                --background-color: #f8fafc;
+                --secondary-background-color: #ffffff;
+                --text-color: #1a202c;
+                --font-family: 'Inter', sans-serif;
+            }
+
+            .stApp {
+                background-color: var(--background-color);
+                color: var(--text-color);
+                font-family: var(--font-family);
+            }
+
+            a, .stMarkdown a {
+                color: var(--primary-color);
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/ui/ultimate_job_dashboard.py
+++ b/ui/ultimate_job_dashboard.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
 import yaml
 
+from theme import apply_theme
+
 # Add parent directory to path for imports
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -46,11 +48,13 @@ st.set_page_config(
     initial_sidebar_state="expanded"
 )
 
+apply_theme()
+
 # Custom CSS for modern design
 st.markdown("""
 <style>
     .main-header {
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
         padding: 2rem;
         border-radius: 15px;
         margin-bottom: 2rem;
@@ -63,7 +67,7 @@ st.markdown("""
         padding: 1.5rem;
         border-radius: 10px;
         box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-        border-left: 4px solid #667eea;
+        border-left: 4px solid var(--primary-color);
         margin-bottom: 1rem;
     }
     


### PR DESCRIPTION
## Summary
- Load AI service API keys from environment variables to avoid hard-coded placeholders
- Expose a reusable `calculate_total_experience` helper and invoke it when merging parsed results or parsing PDFs
- Extend unit tests to cover the standalone experience helper
- Centralize Streamlit theming and apply a consistent palette across dashboards

## Testing
- `pytest tests/unit/test_multi_ai_resume_parser.py -q`
- `python parser/resume_parser.py` *(fails: No PDF extraction methods available)*

------
https://chatgpt.com/codex/tasks/task_e_68bff09aa1c08323a896fae614de1cf7